### PR TITLE
Use urlendcode format log

### DIFF
--- a/python/install.sh
+++ b/python/install.sh
@@ -1,3 +1,3 @@
 project=pyjava
-version=0.3.1
+version=0.3.2
 rm -rf ./dist/* && pip uninstall -y ${project} && python setup.py sdist bdist_wheel && cd ./dist/ && pip install ${project}-${version}-py3-none-any.whl && cd -

--- a/python/pyjava/api/mlsql.py
+++ b/python/pyjava/api/mlsql.py
@@ -1,8 +1,9 @@
 import logging
 import os
 import socket
-import time
 import uuid
+from urllib.parse import quote
+import json
 
 import pandas as pd
 import sys
@@ -44,13 +45,12 @@ class LogClient(object):
             else:
                 logging.info(msg)
             return
-        import json
         resp = json.dumps(
             {"sendLog": {
                 "token": self.log_token,
                 "logLine": "[owner] [{}] [groupId] [{}] __MMMMMM__ {}".format(self.log_user, self.log_group_id, msg)
             }}, ensure_ascii=False)
-        requests.post(self.url, data=resp, headers={'content-type': 'application/x-www-form-urlencoded;charset=UTF-8'})
+        requests.post(self.url, data=resp, headers={'Content-Type': 'application/json;charset=UTF-8'})
 
     def close(self):
         if hasattr(self, "conn"):


### PR DESCRIPTION
When I tested in the morning, I found that the "=" or "&" in the request data would cause the log display to be incomplete. It was located because the encoding method of sending data in fluemt is: Content-Type=application/x-www-form-urlencoded format, This format requires the data to be encoded in the way of key1=val1&key2=val2. If there is a "=" separator, it will be split into multiple sets of parameters, and I only took the first set of json text data in jetty server side.